### PR TITLE
Remove `principal_type` to allow manual user deployments

### DIFF
--- a/.github/workflows/terraform-storage.yml
+++ b/.github/workflows/terraform-storage.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       environment: "dev"
       config: "storage"
-      terraform_version: "1.9.6"
+      terraform_version: "1.9.8"
       node_version: 20
       tenant_id: "37963dd4-f4e6-40f8-a7d6-24b97919e452"
       subscription_id: "1fdab118-1638-419a-8b12-06c9543714a0"

--- a/modules/storage/README.md
+++ b/modules/storage/README.md
@@ -10,9 +10,9 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>=0.12)
 
-- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 4.0.0)
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.0)
 
-- <a name="requirement_time"></a> [time](#requirement\_time) (>= 0.9.1)
+- <a name="requirement_time"></a> [time](#requirement\_time) (~> 0.9)
 
 ## Modules
 

--- a/modules/storage/roleassignments.tf
+++ b/modules/storage/roleassignments.tf
@@ -3,5 +3,4 @@ resource "azurerm_role_assignment" "current_roleassignment_storage_blob_data_own
   scope                = azurerm_storage_account.storage_account.id
   role_definition_name = "Storage Blob Data Owner"
   principal_id         = data.azurerm_client_config.current.object_id
-  principal_type       = "ServicePrincipal"
 }

--- a/modules/storage/terraform.tf
+++ b/modules/storage/terraform.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.0.0"
+      version = "~> 4.0"
     }
     time = {
       source  = "hashicorp/time"
-      version = ">= 0.9.1"
+      version = "~> 0.9"
     }
   }
 }


### PR DESCRIPTION
**Proposed changes**:
- Remove `principal_type` to allow manual user deployments
- Update terraform version to `v1.9.8`
- Update storage module provider versions
